### PR TITLE
fix null type issue and refactor test code

### DIFF
--- a/velox/cider/VeloxToCiderExpr.cpp
+++ b/velox/cider/VeloxToCiderExpr.cpp
@@ -206,7 +206,7 @@ std::shared_ptr<Analyzer::Expr> VeloxToCiderExprConverter::toCiderExpr(
   }
   auto colIndex = it->second;
   // TODO: how to determine isNullable? use true for now
-  auto colType = getCiderType(vExpr->type(), true);
+  auto colType = getCiderType(vExpr->type(), false);
   // TODO: fixed fake table id 100
   return std::make_shared<Analyzer::ColumnVar>(colType, 100, colIndex, 0);
 }


### PR DESCRIPTION
For filter expressions, omnisci will generate code based on input expr info, see CompareIR.cpp L471. And we will set some column to true which means it's don't contains null value.
