### PR TITLE
[POAE7-1474] Implement data conversion round trip between velox and omnisci with arrow for basic types

### DIFF
--- a/velox/omnisci/ArrowDataConvertor.cpp
+++ b/velox/omnisci/ArrowDataConvertor.cpp
@@ -13,12 +13,127 @@
  */
 #include "velox/omnisci/ArrowDataConvertor.h"
 namespace facebook::velox::cider {
+template <TypeKind kind>
+void toCiderWithArrowImpl(
+    VectorPtr& child,
+    int idx,
+    int8_t*** col_buffer_ptr,
+    int num_rows) {
+  using T = typename TypeTraits<kind>::NativeType;
+  int8_t** col_buffer = *col_buffer_ptr;
+  // velox to arrow
+  ArrowArray arrowArray;
+  exportToArrow(child, arrowArray);
+  // arrow to cider
+  const uint64_t* nulls =
+      reinterpret_cast<const uint64_t*>(arrowArray.buffers[0]);
+  const T* values = reinterpret_cast<const T*>(arrowArray.buffers[1]);
+  // cannot directly change arrow buffers as const array, need memcpy
+  T* column = (T*)std::malloc(sizeof(T) * num_rows);
+  memcpy(column, values, sizeof(T) * num_rows);
+  // null_count MAY be -1 if not yet computed.
+  if (arrowArray.null_count != 0) {
+    for (auto pos = 0; pos < num_rows; pos++) {
+      if (bits::isBitNull(nulls, pos)) {
+        if (std::is_integral<T>::value) {
+          column[pos] = inline_int_null_value<T>();
+        } else if (std::is_same<T, float>::value) {
+          column[pos] = FLT_MIN;
+        } else if (std::is_same<T, double>::value) {
+          column[pos] = DBL_MIN;
+        } else {
+          VELOX_NYI("Conversion is not supported yet");
+        }
+      }
+    }
+  }
+  col_buffer[idx] = reinterpret_cast<int8_t*>(column);
+  arrowArray.release(&arrowArray);
+}
+
+template <>
+void toCiderWithArrowImpl<TypeKind::BOOLEAN>(
+    VectorPtr& child,
+    int idx,
+    int8_t*** col_buffer_ptr,
+    int num_rows) {
+  VELOX_NYI("Conversion is not supported yet");
+}
+
+template <>
+void toCiderWithArrowImpl<TypeKind::VARCHAR>(
+    VectorPtr& child,
+    int idx,
+    int8_t*** col_buffer_ptr,
+    int num_rows) {
+  VELOX_NYI(" {} conversion is not supported yet");
+}
+
+template <>
+void toCiderWithArrowImpl<TypeKind::VARBINARY>(
+    VectorPtr& child,
+    int idx,
+    int8_t*** col_buffer_ptr,
+    int num_rows) {
+  VELOX_NYI(" {} conversion is not supported yet");
+}
+
+template <>
+void toCiderWithArrowImpl<TypeKind::TIMESTAMP>(
+    VectorPtr& child,
+    int idx,
+    int8_t*** col_buffer_ptr,
+    int num_rows) {
+  VELOX_NYI(" {} conversion is not supported yet");
+}
+
+void toCiderWithArrow(
+    VectorPtr& child,
+    int idx,
+    int8_t*** col_buffer_ptr,
+    int num_rows) {
+  return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+      toCiderWithArrowImpl,
+      child->typeKind(),
+      child,
+      idx,
+      col_buffer_ptr,
+      num_rows);
+}
+
 CiderResultSet ArrowDataConvertor::convertToCider(
     RowVectorPtr input,
     int num_rows,
     std::chrono::microseconds* timer) {
-  // TODO
-  VELOX_NYI("Arrow conversion not yet supported.");
+  RowVector* row = input.get();
+  auto* rowVector = row->as<RowVector>();
+  auto size = rowVector->childrenSize();
+  int8_t** col_buffer = (int8_t**)std::malloc(sizeof(int8_t*) * size);
+  auto col_buffer_ptr = &col_buffer;
+  for (auto idx = 0; idx < size; idx++) {
+    VectorPtr& child = rowVector->childAt(idx);
+    switch (child->encoding()) {
+      case VectorEncoding::Simple::FLAT:
+        toCiderWithArrow(child, idx, col_buffer_ptr, num_rows);
+        break;
+      case VectorEncoding::Simple::LAZY: {
+        // For LazyVector, we will load it here and use as TypeVector to use.
+        auto tic = std::chrono::system_clock::now();
+        auto vec = (std::dynamic_pointer_cast<LazyVector>(child))
+                       ->loadedVectorShared();
+        auto toc = std::chrono::system_clock::now();
+        if (timer) {
+          *timer +=
+              std::chrono::duration_cast<std::chrono::microseconds>(toc - tic);
+        }
+        toCiderWithArrow(vec, idx, col_buffer_ptr, num_rows);
+        break;
+      }
+      default:
+        VELOX_NYI(" {} conversion is not supported yet", child->encoding());
+    }
+  }
+  return CiderResultSet(col_buffer, num_rows);
 };
 
 RowVectorPtr ArrowDataConvertor::convertToRowVector(

--- a/velox/omnisci/ArrowDataConvertor.h
+++ b/velox/omnisci/ArrowDataConvertor.h
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "velox/omnisci/DataConvertor.h"
+#include "velox/vector/arrow/Bridge.h"
 
 namespace facebook::velox::cider {
 class ArrowDataConvertor : public DataConvertor {

--- a/velox/omnisci/CMakeLists.txt
+++ b/velox/omnisci/CMakeLists.txt
@@ -11,7 +11,7 @@
 # limitations under the License.
 add_library(data_convert DataConvertor.cpp RawDataConvertor.cpp ArrowDataConvertor.cpp)
 
-target_link_libraries(data_convert velox_vector) 
+target_link_libraries(data_convert velox_vector velox_arrow_bridge) 
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/omnisci/CiderNullValues.h
+++ b/velox/omnisci/CiderNullValues.h
@@ -25,7 +25,6 @@
 #define CONSTEXPR constexpr
 
 using namespace facebook::velox;
-
 namespace facebook::velox::cider {
 template <class T>
 constexpr inline int64_t inline_int_null_value() {

--- a/velox/omnisci/RawDataConvertor.cpp
+++ b/velox/omnisci/RawDataConvertor.cpp
@@ -358,18 +358,12 @@ RowVectorPtr RawDataConvertor::convertToRowVector(
     memory::MemoryPool* pool) {
   std::shared_ptr<const RowType> rowType;
   std::vector<VectorPtr> columns;
-
-  // get row type from cider result
   std::vector<TypePtr> types;
   int num_cols = col_types.size();
   types.reserve(num_cols);
-  for (int i = 0; i < num_cols; i++) {
-    types.push_back(getVeloxType(col_types[i]));
-  }
-
-  // convert col buffer to vector ptr
   columns.reserve(num_cols);
   for (int i = 0; i < num_cols; i++) {
+    types.push_back(getVeloxType(col_types[i]));
     columns.push_back(
         toVeloxVector(types[i], col_buffer[i], num_rows, pool, dimens[i]));
   }

--- a/velox/omnisci/RawDataConvertor.cpp
+++ b/velox/omnisci/RawDataConvertor.cpp
@@ -15,7 +15,6 @@
 #include "velox/vector/FlatVector.h"
 
 namespace facebook::velox::cider {
-
 template <TypeKind kind>
 void toCiderImpl(
     VectorPtr& child,

--- a/velox/omnisci/tests/CMakeLists.txt
+++ b/velox/omnisci/tests/CMakeLists.txt
@@ -16,6 +16,6 @@ add_test(cider_data_convert_test cider_data_convert_test)
 target_link_libraries(
   cider_data_convert_test
   velox_vector_test_lib
-  data_convert
+  data_convert  
   ${GTEST_BOTH_LIBRARIES}
 )


### PR DESCRIPTION
convert velox vector to cider col buffer through arrow. As velox to arrow is already implemented as exportToArrow, directly use that function and implement arrow to cider. Here zero copy seems hard as arrow array's buffer is set to const but we need change the null represent for cider side. 