### PR TITLE
[POAE7-2603] bridge support date type

### DIFF
--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -423,6 +423,7 @@ void exportFlat(
     case TypeKind::DOUBLE:
     case TypeKind::SHORT_DECIMAL:
     case TypeKind::LONG_DECIMAL:
+    case TypeKind::DATE:
       exportValues(vec, rows, out, pool, holder);
       break;
     case TypeKind::VARCHAR:


### PR DESCRIPTION
Bridge support date conversion when export Velox vector to Arrow. 